### PR TITLE
Added automatic (audit) stamping support on entities

### DIFF
--- a/audit-test/grails-app/domain/test/Coach.groovy
+++ b/audit-test/grails-app/domain/test/Coach.groovy
@@ -1,0 +1,8 @@
+package test
+
+@MyStamp
+class Coach {
+
+    static constraints = {
+    }
+}

--- a/audit-test/grails-app/domain/test/Train.groovy
+++ b/audit-test/grails-app/domain/test/Train.groovy
@@ -1,0 +1,11 @@
+package test
+
+import org.codehaus.groovy.grails.plugins.orm.auditable.Stamp
+
+@Stamp
+class Train {
+	String number
+	
+    static constraints = {
+    }
+}

--- a/audit-test/src/java/test/MyStamp.java
+++ b/audit-test/src/java/test/MyStamp.java
@@ -1,0 +1,25 @@
+package test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Date;
+
+import org.codehaus.groovy.grails.plugins.orm.auditable.StampInfo;
+import org.codehaus.groovy.transform.GroovyASTTransformationClass;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.TYPE})
+@GroovyASTTransformationClass({"org.codehaus.groovy.grails.plugins.orm.auditable.StampASTTransformation"})
+public @interface MyStamp {
+	
+	StampInfo removed() default @StampInfo(type=Boolean.class);
+	
+	StampInfo dateCreated() default @StampInfo(type=Date.class);
+	StampInfo lastUpdated() default @StampInfo(type=Date.class);
+	
+	StampInfo createdBy() default @StampInfo(type=String.class, nullable=true);
+	StampInfo lastUpdatedBy() default @StampInfo(type=String.class,nullable=true);
+	
+}

--- a/audit-test/test/integration/test/StampSpec.groovy
+++ b/audit-test/test/integration/test/StampSpec.groovy
@@ -1,0 +1,56 @@
+package test
+
+import grails.test.spock.IntegrationSpec
+import org.codehaus.groovy.grails.commons.GrailsClassUtils as GCU;
+
+class StampSpec extends IntegrationSpec{
+	def setup(){
+		assert Train.stampable
+	}
+	
+	void 'Test Stamp AST transformations'(){
+		given:
+			def train = new Train()
+		when:
+			def expectedProperties = [
+				'dateCreated':Date.class,
+				'lastUpdated':Date.class,
+				'lastUpdatedBy':String.class,
+				'createdBy':String.class
+			]
+		then:
+			expectedProperties.each{
+				assert train.hasProperty(it.key)
+				assert GCU.getPropertyType(Train.class,it.key) == it.value
+			}
+	}
+	
+	void 'Test custom Stamp AST transformation'(){
+		given:
+			def coach = new Coach()
+		when:
+			def expectedProperties = [
+				'dateCreated':Date.class,
+				'lastUpdated':Date.class,
+				'lastUpdatedBy':String.class,
+				'createdBy':String.class,
+				'removed':Boolean.class
+			]
+		then:
+			expectedProperties.each{
+				assert coach.hasProperty(it.key)
+				assert GCU.getPropertyType(Coach.class,it.key) == it.value
+			}
+	}
+	
+	void 'Test Auto Stamp'(){
+		given: 
+			def train = new Train()
+		when:
+			train.number="10"
+			train.save(flush:true)
+		then: 
+			train.createdBy == 'SYS'
+			train.lastUpdatedBy == 'SYS'
+	}
+}

--- a/grails-audit-logging-plugin/AuditLoggingGrailsPlugin.groovy
+++ b/grails-audit-logging-plugin/AuditLoggingGrailsPlugin.groovy
@@ -109,7 +109,12 @@ When called, the event handlers have access to oldObj and newObj definitions tha
                 def listener = new AuditLogListener(datastore)
                 listener.with {
                     grailsApplication = application
-                    verbose = application.config.auditLog.verbose ?: false
+					
+					stampEnabled = application.config.auditLog.stampEnabled ?: true
+					stampAlways = application.config.auditLog.stampAlways ?: false
+					stampCreatedBy = application.config.auditLog.stampCreatedBy ?: 'createdBy'
+					stampLastUpdatedBy = application.config.auditLog.stampLastUpdatedBy ?: 'lastUpdatedBy'
+					verbose = application.config.auditLog.verbose ?: false
                     nonVerboseDelete = application.config.auditLog.nonVerboseDelete ?: false
                     logFullClassName = application.config.auditLog.logFullClassName ?: false
                     transactional = application.config.auditLog.transactional ?: false

--- a/grails-audit-logging-plugin/src/groovy/org/codehaus/groovy/grails/plugins/orm/auditable/AuditLogListenerUtil.groovy
+++ b/grails-audit-logging-plugin/src/groovy/org/codehaus/groovy/grails/plugins/orm/auditable/AuditLogListenerUtil.groovy
@@ -19,9 +19,11 @@
 package org.codehaus.groovy.grails.plugins.orm.auditable
 
 import grails.util.Holders
+
 import org.codehaus.groovy.grails.commons.DomainClassArtefactHandler
 import org.codehaus.groovy.grails.commons.GrailsDomainClass
 import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
+import org.grails.datastore.mapping.engine.event.EventType;
 import org.grails.datastore.mapping.reflect.ClassPropertyFetcher
 
 import javax.servlet.http.HttpSession
@@ -57,7 +59,21 @@ class AuditLogListenerUtil {
         // Anything that get's this far is auditable
         return true
     }
-
+	
+	static isStampable(domain,EventType eventType) {
+		boolean stampable =  isStampable(eventType)
+		if(stampable){
+			def cpf = ClassPropertyFetcher.forClass(domain.class)
+			stampable = cpf.getPropertyValue('stampable')
+		}
+		stampable
+	}
+	
+	static isStampable(EventType eventType){
+		eventType == EventType.PreDelete || eventType == EventType.PreUpdate || eventType == EventType.PreInsert
+	}
+	
+	
     /**
      * The static auditable attribute for the given domain class or null if none exists
      */

--- a/grails-audit-logging-plugin/src/java/org/codehaus/groovy/grails/plugins/orm/auditable/AbstractASTTransformation.java
+++ b/grails-audit-logging-plugin/src/java/org/codehaus/groovy/grails/plugins/orm/auditable/AbstractASTTransformation.java
@@ -1,0 +1,329 @@
+package org.codehaus.groovy.grails.plugins.orm.auditable;
+
+import static org.springframework.asm.Opcodes.ACC_PUBLIC;
+import groovy.lang.Closure;
+
+import java.lang.reflect.Modifier;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.AnnotationNode;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.FieldNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.Parameter;
+import org.codehaus.groovy.ast.VariableScope;
+import org.codehaus.groovy.ast.expr.BinaryExpression;
+import org.codehaus.groovy.ast.expr.ClosureExpression;
+import org.codehaus.groovy.ast.expr.ConstantExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.FieldExpression;
+import org.codehaus.groovy.ast.expr.ListExpression;
+import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.expr.NamedArgumentListExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.ast.stmt.BlockStatement;
+import org.codehaus.groovy.ast.stmt.ExpressionStatement;
+import org.codehaus.groovy.ast.stmt.ReturnStatement;
+import org.codehaus.groovy.ast.stmt.Statement;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.syntax.Token;
+import org.codehaus.groovy.syntax.Types;
+import org.codehaus.groovy.transform.ASTTransformation;
+
+public abstract class AbstractASTTransformation implements ASTTransformation {
+	
+	
+	@Override
+	public void visit(ASTNode[] nodes, SourceUnit sourceUnit) {
+		AnnotationNode annotation = (AnnotationNode) nodes[0];
+		for (ASTNode aSTNode : nodes) {
+			if (aSTNode instanceof ClassNode) {
+				try {
+					transformGeneral(annotation,(ClassNode) aSTNode);
+				}
+				catch(Exception exception){
+					exception.printStackTrace();
+				}
+				
+				break;
+			}
+		}
+	}
+	
+	
+	protected boolean hasField(ClassNode cNode,String name){
+		return getField(cNode,name) != null;
+	}
+	protected FieldNode getField(ClassNode cNode,String name){
+		return cNode.getDeclaredField(name);
+	}
+	
+	public Object getMemberValue(AnnotationNode node, String name,Object defaultValue) {
+        final Expression member = node.getMember(name);
+        Object result = null;
+        if (member != null && member instanceof ConstantExpression) result= ((ConstantExpression) member).getValue();
+        
+        if(result==null) result = defaultValue;
+        return result;
+    }
+	
+	
+	public FieldNode addBooleanFieldNode(ClassNode node,String fieldName,boolean defaultValue){
+		FieldNode fieldNode = createFieldNode(node,fieldName,Modifier.PRIVATE,ClassHelper.boolean_TYPE,new ConstantExpression(defaultValue,true));
+		addIsser(fieldNode,node);
+		addSetter(fieldNode,node);
+		return fieldNode;
+	}
+
+		
+	public FieldNode addFieldNode(ClassNode node,String fieldName,Class<?> fieldType){
+		return addFieldNode(node,fieldName,fieldType,null);
+	}
+	public FieldNode addFieldNode(ClassNode node,String fieldName,Class<?> fieldType,Expression defaultValue){
+		FieldNode field = createFieldNode(node,fieldName,Modifier.PRIVATE,new ClassNode(fieldType),defaultValue);
+		addGetter(field,node);
+		addSetter(field,node);
+		return field;
+	}
+	
+	public FieldNode createFieldNode(ClassNode owner,String fieldName,int modifier,ClassNode fieldTypeNode,Expression defaultValue){
+		FieldNode field = new FieldNode(fieldName,modifier,fieldTypeNode,owner,defaultValue);
+		owner.addField(field);
+		return field;
+	}
+	
+	public abstract void transformGeneral(AnnotationNode annotationNode, ClassNode node);
+
+	
+	protected void addGetter(FieldNode fieldNode, ClassNode owner) {
+		addGetter(fieldNode.getName(), fieldNode, owner, ACC_PUBLIC);
+	}
+
+	protected void addGetter(String name, FieldNode fieldNode, ClassNode owner) {
+		addGetter(name, fieldNode, owner, ACC_PUBLIC);
+	}
+
+	protected void addGetter(FieldNode fieldNode, ClassNode owner, int modifier) {
+		addGetter(fieldNode.getName(), fieldNode, owner, modifier);
+	}
+
+	protected void addGetter(String name, FieldNode fieldNode, ClassNode owner, int modifier) {
+		addGetterOrIsser("get",name,fieldNode,owner,modifier);
+	}
+	protected void addIsser(FieldNode fieldNode, ClassNode owner) {
+		addIsser(fieldNode.getName(), fieldNode, owner, ACC_PUBLIC);
+	}
+
+	protected void addIsser(String name, FieldNode fieldNode, ClassNode owner) {
+		addIsser(name, fieldNode, owner, ACC_PUBLIC);
+	}
+
+	protected void addIsser(FieldNode fieldNode, ClassNode owner, int modifier) {
+		addIsser(fieldNode.getName(), fieldNode, owner, modifier);
+	}
+
+	protected void addIsser(String name, FieldNode fieldNode, ClassNode owner, int modifier) {
+		addGetterOrIsser("is",name,fieldNode,owner,modifier);
+	}
+
+	protected void addGetterOrIsser(String getterType,String name, FieldNode fieldNode, ClassNode owner, int modifier) {
+		ClassNode type = fieldNode.getType();
+		String getterName = getterType + StringUtils.capitalize(name);
+		owner.addMethod(getterName,
+				modifier,
+				nonGeneric(type),
+				Parameter.EMPTY_ARRAY,
+				null,
+				new ReturnStatement(new FieldExpression(fieldNode)));
+	}
+    protected FieldNode addTransientMapping(ClassNode classNode, String fieldName) {
+        FieldNode transients = classNode.getDeclaredField("transients");
+    	if(transients==null){
+    		
+        	transients = new FieldNode("transients",Modifier.STATIC|Modifier.PUBLIC,new ClassNode(List.class),classNode,new ListExpression());
+        	classNode.addField(transients); 
+        } 
+        ListExpression constraintsExpression = (ListExpression) transients.getInitialExpression();
+        if(!hasFieldInList(constraintsExpression,fieldName)){
+        	constraintsExpression.addExpression(new ConstantExpression(fieldName));	
+        } 
+		return transients;
+    }
+    private boolean hasFieldInList(ListExpression constraintsExpression,String fieldName) {
+    	if(constraintsExpression!=null){
+    		for(Expression expression:constraintsExpression.getExpressions()){
+    			if(expression instanceof ConstantExpression){
+    				if(((ConstantExpression)expression).getValue().equals(fieldName)){
+    					return true;
+    				}
+    			}
+    		}
+    	}
+    	return false;
+	}
+
+	protected FieldNode addSqlTypeMapping(ClassNode classNode, FieldNode fieldNode,String sqlType) {
+        FieldNode closure = classNode.getDeclaredField("mapping");
+        if(closure==null){
+        	ClosureExpression constraintsExpression = new ClosureExpression(new Parameter[]{}, new BlockStatement());
+        	constraintsExpression.setVariableScope(new VariableScope());
+        	
+        	closure = new FieldNode("mapping",Modifier.STATIC,new ClassNode(Closure.class),classNode,constraintsExpression);
+        	classNode.addField(closure);
+        }
+        ClosureExpression exp = (ClosureExpression) closure.getInitialExpression();
+        BlockStatement block = (BlockStatement) exp.getCode();
+
+        if (!hasFieldInClosure(closure, fieldNode.getName())) {
+            NamedArgumentListExpression namedarg = new NamedArgumentListExpression();
+            namedarg.addMapEntryExpression(new ConstantExpression("sqlType"), new ConstantExpression(sqlType));
+            MethodCallExpression constExpr = new MethodCallExpression(
+                    VariableExpression.THIS_EXPRESSION,
+                    new ConstantExpression(fieldNode.getName()),
+                    namedarg);
+            block.addStatement(new ExpressionStatement(constExpr));
+        }
+		return fieldNode;
+    }
+	
+	protected <T> FieldNode addStaticField(ClassNode classNode, String fieldname,Class<T> type,T initialValue) {
+		FieldNode fieldNode = classNode.getDeclaredField(fieldname);
+		
+		if(fieldNode==null){
+			fieldNode = new FieldNode(fieldname,Modifier.STATIC+Modifier.PUBLIC,new ClassNode(type),classNode,new ConstantExpression(initialValue));
+			classNode.addField(fieldNode);
+		}
+		return fieldNode;
+	}
+	
+    protected FieldNode addNullableConstraint(ClassNode classNode, FieldNode fieldNode) {
+        FieldNode closure = classNode.getDeclaredField("constraints");
+        if(closure==null){
+        	ClosureExpression constraintsExpression = new ClosureExpression(new Parameter[]{}, new BlockStatement());
+        	constraintsExpression.setVariableScope(new VariableScope());
+        	
+        	closure = new FieldNode("constraints",Modifier.STATIC,new ClassNode(Closure.class),classNode,constraintsExpression);
+        	classNode.addField(closure);
+        }
+        ClosureExpression exp = (ClosureExpression) closure.getInitialExpression();
+        BlockStatement block = (BlockStatement) exp.getCode();
+
+        if (!hasFieldInClosure(closure, fieldNode.getName())) {
+            NamedArgumentListExpression namedarg = new NamedArgumentListExpression();
+            namedarg.addMapEntryExpression(new ConstantExpression("nullable"), new ConstantExpression(true));
+            namedarg.addMapEntryExpression(new ConstantExpression("blank"), new ConstantExpression(true));
+            MethodCallExpression constExpr = new MethodCallExpression(
+                    VariableExpression.THIS_EXPRESSION,
+                    new ConstantExpression(fieldNode.getName()),
+                    namedarg);
+            block.addStatement(new ExpressionStatement(constExpr));
+        }
+		return fieldNode;
+    }
+    
+    protected MethodNode getBeforeInsertMethod(ClassNode node){
+        final String methodName = "beforeInsert";
+        MethodNode beforeInsertMethod = node.getDeclaredMethod(methodName, new Parameter[]{});
+
+        if (beforeInsertMethod == null){
+            beforeInsertMethod = new MethodNode(methodName, Modifier.PUBLIC, new ClassNode(Object.class), new Parameter[]{}, new ClassNode[]{}, new BlockStatement());
+            node.addMethod(beforeInsertMethod);
+        }
+
+        return beforeInsertMethod;
+    }
+
+    protected MethodNode getBeforeUpdateMethod(ClassNode node){
+        final String methodName = "beforeUpdate";
+        MethodNode beforeUpdateMethod = node.getDeclaredMethod(methodName, new Parameter[]{});
+
+        if (beforeUpdateMethod == null){
+            beforeUpdateMethod = new MethodNode(methodName, Modifier.PUBLIC, new ClassNode(Object.class), new Parameter[]{}, new ClassNode[]{}, new BlockStatement());
+            node.addMethod(beforeUpdateMethod);
+        }
+
+        return beforeUpdateMethod;
+    }
+    
+    
+    protected boolean hasFieldInClosure(FieldNode closure, String fieldName) {
+        if (closure != null) {
+            ClosureExpression exp = (ClosureExpression) closure.getInitialExpression();
+            BlockStatement block = (BlockStatement) exp.getCode();
+            List<Statement> ments = block.getStatements();
+            for (Statement expstat : ments) {
+                if (expstat instanceof ExpressionStatement && ((ExpressionStatement) expstat).getExpression() instanceof MethodCallExpression) {
+                    MethodCallExpression methexp = (MethodCallExpression) ((ExpressionStatement) expstat).getExpression();
+                    ConstantExpression conexp = (ConstantExpression) methexp.getMethod();
+                    if (conexp.getValue().equals(fieldName)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+
+	
+	
+	protected ClassNode nonGeneric(ClassNode type) {
+		if (type.isUsingGenerics()) {
+			final ClassNode nonGen = ClassHelper.makeWithoutCaching(type.getName());
+			nonGen.setRedirect(type);
+			nonGen.setGenericsTypes(null);
+			nonGen.setUsingGenerics(false);
+			return nonGen;
+		} else {
+			return type;
+		}
+	}
+	
+	protected void addSetter(FieldNode fieldNode, ClassNode owner) {
+		addSetter(fieldNode, owner, ACC_PUBLIC);
+	}
+
+	protected void addSetter(FieldNode fieldNode, ClassNode owner, int modifier) {
+		ClassNode type = fieldNode.getType();
+		String name = fieldNode.getName();
+		String setterName = "set" + StringUtils.capitalize(name);
+		
+		owner.addMethod(setterName,
+			modifier,
+			ClassHelper.VOID_TYPE,
+			new Parameter[]{new Parameter(nonGeneric(type), "value")},
+			null,
+			new ExpressionStatement(
+				new BinaryExpression(new FieldExpression(fieldNode),
+					Token.newSymbol(Types.EQUAL, -1, -1),
+					new VariableExpression("value"))));
+	}
+	public <T> T getDefaultAnnotationValue(AnnotationNode annotationNode,String memberName,T defaultValue){
+		T result = null;
+		MethodNode methodNode = annotationNode.getClassNode().getMethod(memberName, new Parameter[]{});
+		if(methodNode!=null && methodNode.getCode() instanceof ReturnStatement){
+			ReturnStatement returnStatement = (ReturnStatement) methodNode.getCode();
+			if(returnStatement!=null && returnStatement.getExpression() instanceof ConstantExpression){
+				result = (T) ((ConstantExpression)returnStatement.getExpression()).getValue();
+			}
+		}
+		return result == null? defaultValue:result;
+	}
+	public <T> T getAnnotationValue(AnnotationNode annotationNode,String memberName,T defaultValue){
+		T result = null;
+		
+		Expression expression = annotationNode.getMember(memberName);
+		if(expression !=null && expression instanceof ConstantExpression){
+			result = (T) ((ConstantExpression)expression).getValue();
+		}
+		else{
+			result = getDefaultAnnotationValue(annotationNode, memberName, defaultValue);
+		}
+		return result;
+	}
+	
+	
+}

--- a/grails-audit-logging-plugin/src/java/org/codehaus/groovy/grails/plugins/orm/auditable/Stamp.java
+++ b/grails-audit-logging-plugin/src/java/org/codehaus/groovy/grails/plugins/orm/auditable/Stamp.java
@@ -1,0 +1,22 @@
+package org.codehaus.groovy.grails.plugins.orm.auditable;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Date;
+
+import org.codehaus.groovy.transform.GroovyASTTransformationClass;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.TYPE})
+@GroovyASTTransformationClass({"org.codehaus.groovy.grails.plugins.orm.auditable.StampASTTransformation"})
+public @interface Stamp {
+	
+	StampInfo dateCreated() default @StampInfo(type=Date.class);
+	StampInfo lastUpdated() default @StampInfo(type=Date.class);
+	
+	StampInfo createdBy() default @StampInfo(type=String.class, nullable=true);
+	StampInfo lastUpdatedBy() default @StampInfo(type=String.class,nullable=true);
+	
+}

--- a/grails-audit-logging-plugin/src/java/org/codehaus/groovy/grails/plugins/orm/auditable/StampASTTransformation.java
+++ b/grails-audit-logging-plugin/src/java/org/codehaus/groovy/grails/plugins/orm/auditable/StampASTTransformation.java
@@ -36,8 +36,4 @@ public class StampASTTransformation extends AbstractASTTransformation{
 		T result = (T) InvokerHelper.invokeMethod(stampInfo, field, new Object[]{});
 		return result!=null ? result:defaultValue;
 	}
-	
-	public void out(Object value){
-		System.out.println(value);
-	}
 }

--- a/grails-audit-logging-plugin/src/java/org/codehaus/groovy/grails/plugins/orm/auditable/StampASTTransformation.java
+++ b/grails-audit-logging-plugin/src/java/org/codehaus/groovy/grails/plugins/orm/auditable/StampASTTransformation.java
@@ -1,0 +1,43 @@
+package org.codehaus.groovy.grails.plugins.orm.auditable;
+
+import org.codehaus.groovy.ast.AnnotationNode;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.FieldNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.control.CompilePhase;
+import org.codehaus.groovy.runtime.InvokerHelper;
+import org.codehaus.groovy.transform.GroovyASTTransformation;
+
+@GroovyASTTransformation(phase = CompilePhase.CANONICALIZATION)
+public class StampASTTransformation extends AbstractASTTransformation{
+	@Override
+	public void transformGeneral(AnnotationNode annotationNode, ClassNode node) {
+		addStaticField(node, "stampable", Boolean.class, Boolean.TRUE);
+		for(MethodNode value:annotationNode.getClassNode().getMethods()){
+			String fieldName = value.getName();
+			
+			Object stampInfo = getAnnotationValue(annotationNode, fieldName,true);
+			
+			boolean shouldExclude = getStampInfoValue(stampInfo,"exclude",false);
+			if(!shouldExclude){
+				Class<?> fieldType = getStampInfoValue(stampInfo, "type",String.class);
+				
+				FieldNode fieldNode = addFieldNode(node, fieldName, fieldType);
+				
+				boolean nullable = getStampInfoValue(stampInfo, "nullable",true);
+				if(nullable){
+					addNullableConstraint(node, fieldNode);
+				}
+			}
+		}
+	}
+	
+	private <T> T getStampInfoValue(Object stampInfo,String field,T defaultValue){
+		T result = (T) InvokerHelper.invokeMethod(stampInfo, field, new Object[]{});
+		return result!=null ? result:defaultValue;
+	}
+	
+	public void out(Object value){
+		System.out.println(value);
+	}
+}

--- a/grails-audit-logging-plugin/src/java/org/codehaus/groovy/grails/plugins/orm/auditable/StampInfo.java
+++ b/grails-audit-logging-plugin/src/java/org/codehaus/groovy/grails/plugins/orm/auditable/StampInfo.java
@@ -1,0 +1,7 @@
+package org.codehaus.groovy.grails.plugins.orm.auditable;
+
+public @interface StampInfo{
+	boolean nullable() default true;
+	boolean exclude() default false;
+	Class<?> type() default String.class;
+}


### PR DESCRIPTION
Stamping is enabled by default on all classes which have the static
field stampable = true.
This is set automatically on all domainclasses which have an annotation
which is implemented by StampASTTransformation. @Stamp is the default
implementation which includes dateCreated,createdBy, lastUpdated and
lastUpdatedBy. You are free to implement your own annotation (see
example below) or to do it manually. The createdBy and lastUpdatedBy
fieldnames can be declared in Config.groovy. These will be filled with
the result of the actor closure on the event PreInsert, PreUpdate and
PreDelete.
It's simple to implement your own stamping annotation, use
StampASTTransformation as the transformation implementation.

Example:
@Retention(RetentionPolicy.SOURCE)
@Target({ElementType.TYPE})

@GroovyASTTransformationClass({"org.codehaus.groovy.grails.plugins.orm.auditable.StampASTTransformation"})
public @interface MyStamp {
StampInfo dateCreated() default @StampInfo(type=Date.class);
StampInfo lastUpdated() default @StampInfo(type=Date.class);
StampInfo createdBy() default @StampInfo(type=String.class,
nullable=true);
StampInfo lastUpdatedBy() default
@StampInfo(type=Date.class,nullable=true);
StampInfo removed() default
@StampInfo(type=Boolean.class,nullable=false);
}