### PR TITLE
Allowing false and zero value logging [GPAUDITLOGGING-74]

### DIFF
--- a/audit-test/test/integration/test/AuditUpdateSpec.groovy
+++ b/audit-test/test/integration/test/AuditUpdateSpec.groovy
@@ -58,7 +58,25 @@ class AuditUpdateSpec extends IntegrationSpec {
         def first = events.find { it.propertyName == 'age' }
         first.persistedObjectVersion == author.version - 1
     }
+    
+    void "Test false/null differentiation"() {
+        given:
+        def author = Author.findByName("Aaron")
 
+        when:
+        author.famous = false
+        author.save(flush: true, failOnError: true)
+
+        then:
+        def events = AuditLogEvent.findAllByClassName('test.Author')
+        events.size() == 1
+
+        def first = events.find { it.propertyName == 'famous' }
+        first.oldValue == 'true'
+        first.newValue == 'false'
+        first.eventName == 'UPDATE'
+    }
+    
     void "Test persistedObjectVersion in update logging for domain class without version"() {
         given:
         def heliport = Heliport.findByCode('EGLW')

--- a/grails-audit-logging-plugin/src/groovy/org/codehaus/groovy/grails/plugins/orm/auditable/AuditLogListener.groovy
+++ b/grails-audit-logging-plugin/src/groovy/org/codehaus/groovy/grails/plugins/orm/auditable/AuditLogListener.groovy
@@ -524,7 +524,7 @@ class AuditLogListener extends AbstractPersistenceEventListener {
    */
   String conditionallyMaskAndTruncate(domain, String key, value) {
     try {
-      if (!value) {
+      if (value == null) {
         return null
       }
     } catch (Exception e) {


### PR DESCRIPTION
This is a fix to resolve [GPAUDITLOGGING-74](https://jira.grails.org/browse/GPAUDITLOGGING-74) and allow false and zero values to be differentiated from null values.