### PR TITLE
Ignore Events

### DIFF
--- a/audit-test/grails-app/domain/test/Resolution.groovy
+++ b/audit-test/grails-app/domain/test/Resolution.groovy
@@ -1,0 +1,11 @@
+package test
+
+class Resolution {
+
+	String name
+
+	static auditable = [ignoreEvents:["onChange","onSave"]]
+
+	static constraints = {
+	}
+}

--- a/audit-test/test/integration/test/AuditDeleteSpec.groovy
+++ b/audit-test/test/integration/test/AuditDeleteSpec.groovy
@@ -123,9 +123,8 @@ class AuditDeleteSpec extends IntegrationSpec {
 			resolution.save(flush: true, failOnError: true)
 		when: "updateing resolution"
 			resolution.name = "One for all and all for one"
-			resolution.save(flush: true, failOnError: true)
-			
-		then:
+			resolution.save(flush: true, failOnError: true)			
+		then: "delete resolution"
 			resolution.delete(flush: true, failOnError: true)
 			def events = AuditLogEvent.findAllByClassName('test.Resolution')
 			events.size() == 1

--- a/audit-test/test/integration/test/AuditDeleteSpec.groovy
+++ b/audit-test/test/integration/test/AuditDeleteSpec.groovy
@@ -116,6 +116,23 @@ class AuditDeleteSpec extends IntegrationSpec {
         author.handlerCalled == "onDelete"
     }
 
+	void "Test only delete event is logged" () {
+		given: "create resolution"
+			def resolution = new Resolution()
+			resolution.name = "One for all"
+			resolution.save(flush: true, failOnError: true)
+		when: "updateing resolution"
+			resolution.name = "One for all and all for one"
+			resolution.save(flush: true, failOnError: true)
+			
+		then:
+			resolution.delete(flush: true, failOnError: true)
+			def events = AuditLogEvent.findAllByClassName('test.Resolution')
+			events.size() == 1
+		and:
+			events.get(0).eventName == "DELETE"
+		
+	}
 
 }
 

--- a/audit-test/testapps.config.groovy
+++ b/audit-test/testapps.config.groovy
@@ -1,8 +1,9 @@
 
-String grailsHomeRoot = '/eclipse-common/grails'
+String grailsHomeRoot = "/usr/share"//'/eclipse-common/grails'
 String projectDirCommon = "target"
 String dotGrailsCommon = "${System.properties.getProperty('user.home')}/.grails"
 
+/*
 v20 {
 	grailsVersion = '2.0.4'
 	pluginVersion = version
@@ -33,7 +34,7 @@ v22 {
 	dotGrails = dotGrailsCommon
 	projectDir = projectDirCommon
 	grailsHome = grailsHomeRoot + '/grails-' + grailsVersion
-}
+}*/
 
 v23 {
 	grailsVersion = '2.3.11'
@@ -43,10 +44,11 @@ v23 {
 	grailsHome = grailsHomeRoot + '/grails-' + grailsVersion
 }
 
+/*
 v24 {
 	grailsVersion = '2.4.2'
 	pluginVersion = version
 	dotGrails = dotGrailsCommon
 	projectDir = projectDirCommon
 	grailsHome = grailsHomeRoot + '/grails-' + grailsVersion
-}
+}*/

--- a/audit-test/testapps.config.groovy
+++ b/audit-test/testapps.config.groovy
@@ -1,9 +1,9 @@
 
-String grailsHomeRoot = "/usr/share"//'/eclipse-common/grails'
+String grailsHomeRoot = '/eclipse-common/grails'
 String projectDirCommon = "target"
 String dotGrailsCommon = "${System.properties.getProperty('user.home')}/.grails"
 
-/*
+
 v20 {
 	grailsVersion = '2.0.4'
 	pluginVersion = version
@@ -34,7 +34,7 @@ v22 {
 	dotGrails = dotGrailsCommon
 	projectDir = projectDirCommon
 	grailsHome = grailsHomeRoot + '/grails-' + grailsVersion
-}*/
+}
 
 v23 {
 	grailsVersion = '2.3.11'
@@ -44,11 +44,11 @@ v23 {
 	grailsHome = grailsHomeRoot + '/grails-' + grailsVersion
 }
 
-/*
+
 v24 {
 	grailsVersion = '2.4.2'
 	pluginVersion = version
 	dotGrails = dotGrailsCommon
 	projectDir = projectDirCommon
 	grailsHome = grailsHomeRoot + '/grails-' + grailsVersion
-}*/
+}


### PR DESCRIPTION
Hi,
     I've add a new feature that ignore events that you don't want to be registered. For instance, we have a product that it is no necessary to have logs when it is created or updated but we want to know when was deleted.

    It's easy to use it. The user has to specified which events want to ignore. Example:

        static auditable = [ignoreEvents:["onChange","onSave"]]
  
Best regards.