### PR TITLE
More flexible id mapping configuration for AuditLogEvent ver 1.x

### DIFF
--- a/grails-audit-logging-plugin/grails-app/domain/org/codehaus/groovy/grails/plugins/orm/auditable/AuditLogEvent.groovy
+++ b/grails-audit-logging-plugin/grails-app/domain/org/codehaus/groovy/grails/plugins/orm/auditable/AuditLogEvent.groovy
@@ -81,8 +81,7 @@ class AuditLogEvent implements Serializable {
 
         // GPAUDITLOGGING-29 support configurable id mapping for AuditLogEvent
         if (Holders.config.auditLog.idMapping) {
-          def map = Holders.config.auditLog.idMapping
-          id generator:map.generator, type:map.type, length:map.length
+          id (Holders.config.auditLog.idMapping)
         } else {
           id generator:'native', type:'long' // default
         }

--- a/grails-audit-logging-plugin/grails-app/domain/org/codehaus/groovy/grails/plugins/orm/auditable/AuditLogEvent.groovy
+++ b/grails-audit-logging-plugin/grails-app/domain/org/codehaus/groovy/grails/plugins/orm/auditable/AuditLogEvent.groovy
@@ -79,11 +79,13 @@ class AuditLogEvent implements Serializable {
           datasource "$Holders.config.auditLog.useDatasource"
         }
 
-        // GPAUDITLOGGING-29 support configurable id mapping for AuditLogEvent
+        // GPAUDITLOGGING-29 support configurable id mapping for AuditLogEvent 
+        // enhanced with #101
         if (Holders.config.auditLog.idMapping) {
-          id (Holders.config.auditLog.idMapping)
+            def idMappingMapCopy = [:] << Holders.config.auditLog.idMapping
+            id (idMappingMapCopy)
         } else {
-          id generator:'native', type:'long' // default
+            id generator: 'native', type: 'long' // default
         }
 
         autoImport false


### PR DESCRIPTION
With version 1.0.4 the default id generator was changed from `native` to `increment`.
On certain databases it's better to use sequences.
The configurable idMapping that was introduced with ver. 1.0.4 is quite limited and doesn't allow to set all available properties for id field (https://grails.github.io/grails-doc/latest/ref/Database%20Mapping/id.html)

This small fix allows to pass any supported parameter for the id field and is also backward compatible with the previous implementation.

I can now configure the plugin to still use the sequence with the following configuration in Config.groovy
```
auditLog {
    ...
    idMapping = [generator: 'sequence', params: [sequence: 'seq_audit_log'], type: 'long']
    ...
}
```