### PR TITLE
Issue #109: Adding ability to specify index property of non-id column…

### DIFF
--- a/audit-logging/grails-app/domain/grails/plugins/orm/auditable/AuditLogEvent.groovy
+++ b/audit-logging/grails-app/domain/grails/plugins/orm/auditable/AuditLogEvent.groovy
@@ -87,6 +87,15 @@ class AuditLogEvent implements Serializable {
           id generator:'increment', type:'long' // default
         }
 
+        // Issue #109: support custom indices
+        if (Holders.config.auditLog.columnMappings) {
+          Holders.config.auditLog.columnMappings.each { c ->
+            if (c.name != 'id') {
+              "$c.name"(index: c.index)
+            }
+          }
+        }
+
         autoImport false
         version false
     }

--- a/audit-logging/src/docs/guide/usage/configuration.gdoc
+++ b/audit-logging/src/docs/guide/usage/configuration.gdoc
@@ -184,6 +184,24 @@ auditLog {
 
 If you change the tablename, you need to update your database schema(s).
 
+h3. Custom Indices
+
+You can specify a list of column property maps to declare custom indices for the audit log table.  Each map requires a 'name' attribute to identify the column and an 'index' attribute to specify the index names that column is a part of.  These values get baked directly into the domain object and are therefore compatible with the database migration plugin.  Desired values are specified in Config.groovy:
+
+{code}
+auditLog {
+    columnProperties = [
+            [name: 'persistedObjectId', index: 'al_idx_001,al_idx_002'],
+            [name: 'id', index: 'al_idx_001'],
+            [name: 'oldValue', index: 'al_idx_002']
+    ]
+}
+{code}
+
+{warning}
+No spaces are allowed in the 'index' value, a restriction of the GORM mapping 'index' attribute.
+{warning}
+
 h3. Disable Hibernate caching of AuditLogEvent
 
 You can disable the caching of the AuditLogEvents by specifying:


### PR DESCRIPTION
… mappings

Non-id columns can have their GORM 'index' mapping value passed through from Config.groovy to the AuditLogEvent class.  This allows adding custom indices to the audit log table, compatible with the database migration plugin.  The index value can be a comma-separated list of index names the column is a part of, but no spaces are allowed (per standard GORM behavior).  Config values are packaged in generic 'columnMappings' object in case additional properties of the column mappings should be made accessible in future updates.