### PR TITLE
Updated syncHibernateState to use correct name array.

### DIFF
--- a/audit-logging/src/main/groovy/grails/plugins/orm/auditable/AuditLogListener.groovy
+++ b/audit-logging/src/main/groovy/grails/plugins/orm/auditable/AuditLogListener.groovy
@@ -333,7 +333,7 @@ class AuditLogListener extends AbstractPersistenceEventListener {
 
     private void syncHibernateState(AbstractPersistenceEvent event,String propertyName,Object value){
         //event.nativeEvent.getPersister().getEntityMetamodel().getPropertyNames();
-        String[] propertyNames = event.nativeEvent.persister.entityMetamodel.propertyNames
+        String[] propertyNames = event.nativeEvent.persister.entityMetamodel.properties*.name
         Object[] state = event.nativeEvent.state
 
         int index = ArrayUtils.indexOf(propertyNames, propertyName);


### PR DESCRIPTION
This is a small fix to resolve the problem that the propertyNames array of the entityModel might be different than the properties array. I have received an error updating to the latest GORM version.

[Link to Screenshot](https://docs.google.com/a/tradeledger.io/document/d/12MYSUhmcex85xora-epPeXdd-0oWV8Rd994GiN0Fr8E/edit?usp=sharing)