### PR TITLE
Update configuration.adoc

### DIFF
--- a/audit-logging/src/docs/configuration.adoc
+++ b/audit-logging/src/docs/configuration.adoc
@@ -239,7 +239,7 @@ Old- and new values are stored in detailed to the audit logging table. Enable ve
 
 ----
 
-This setting is disabled by default.
+This setting is enabled by default.
 
 [WARNING]
 ====


### PR DESCRIPTION
Both the table at the top and the actual code (https://github.com/robertoschwald/grails-audit-logging-plugin/blob/2.0.4/audit-logging/grails-app/conf/DefaultAuditLogConfig.groovy#L20) indicate that verbose is *enabled* by default.