### PR TITLE
Rename isAuditLogEnabled back to isAuditable; Don't extend GormEntity

### DIFF
--- a/examples/audit-test/grails-app/domain/test/Publisher.groovy
+++ b/examples/audit-test/grails-app/domain/test/Publisher.groovy
@@ -15,7 +15,7 @@ class Publisher implements Auditable {
     }
 
     @Override
-    boolean isAuditLogEnabled(AuditEventType eventType) {
+    boolean isAuditable(AuditEventType eventType) {
         active
     }
 

--- a/examples/audit-test/src/integration-test/groovy/test/AuditableSpec.groovy
+++ b/examples/audit-test/src/integration-test/groovy/test/AuditableSpec.groovy
@@ -8,6 +8,7 @@ import grails.plugins.orm.auditable.Auditable
 import grails.plugins.orm.auditable.resolvers.AuditRequestResolver
 import grails.spring.BeanBuilder
 import grails.testing.mixin.integration.Integration
+import org.grails.datastore.gorm.GormEntity
 import org.springframework.test.annotation.DirtiesContext
 import spock.lang.Shared
 import spock.lang.Specification
@@ -21,15 +22,6 @@ class AuditableSpec extends Specification {
 
     void setup() {
         entity = new TestEntity(property: 'foo')
-    }
-
-    void "audit logging is disabled when disabled flag set"(Boolean flag, result) {
-        expect:
-        AuditLogContext.withConfig(disabled: flag) { entity.isAuditLogEnabled() } == result
-        where:
-        flag  | result
-        true  | false
-        false | true
     }
 
     void "excluded properties are respected"() {
@@ -201,7 +193,7 @@ class AuditableSpec extends Specification {
 }
 
 @SuppressWarnings("GroovyUnusedDeclaration")
-class TestEntity implements Auditable {
+class TestEntity implements Auditable, GormEntity<TestEntity> {
     String property
     String otherProperty
     String anotherProperty

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -45,7 +45,7 @@ repositories {
 }
 
 dependencies {
-    profile "org.grails.profiles:plugin"
+    profile "org.grails.profiles:web-plugin"
     compile "org.springframework.boot:spring-boot-starter-logging"
     compile "org.springframework.boot:spring-boot-autoconfigure"
     compile "org.grails:grails-core"

--- a/plugin/grails-app/conf/application.yml
+++ b/plugin/grails-app/conf/application.yml
@@ -1,5 +1,5 @@
 grails:
-    profile: plugin
+    profile: web-plugin
     codegen:
         defaultPackage: audit.logging
     mime:

--- a/plugin/src/docs/usage.adoc
+++ b/plugin/src/docs/usage.adoc
@@ -59,7 +59,7 @@ To override auditing for a specific entity or based on runtime values, just over
 ----
 // Assuming this domain has a status attribute, disable auditing for anything not active, for example
 @Override
-boolean isAuditLogEnabled() {
+boolean isAuditable() {
     this.status == ACTIVE
 }
 ----

--- a/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogListener.groovy
+++ b/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogListener.groovy
@@ -68,7 +68,7 @@ class AuditLogListener extends AbstractPersistenceEventListener {
             AuditEventType auditEventType = AuditEventType.forEventType(event.eventType)
             Auditable domain = event.entityObject as Auditable
 
-            if (domain.isAuditLogEnabled(auditEventType)) {
+            if (domain.isAuditable(auditEventType)) {
                 log.trace("Audit logging: Event {} for object {}", auditEventType, event.entityObject.class.name)
 
                 switch (event.eventType) {

--- a/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogListenerUtil.groovy
+++ b/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogListenerUtil.groovy
@@ -72,7 +72,7 @@ class AuditLogListenerUtil {
     static Object getPersistentValue(Auditable domain, String propertyName) {
         PersistentEntity entity = getPersistentEntity(domain)
         PersistentProperty property = entity.getPropertyByName(propertyName)
-        property instanceof ToMany ? "N/A" : domain.getPersistentValue(propertyName)
+        property instanceof ToMany ? "N/A" : ((GormEntity)domain).getPersistentValue(propertyName)
     }
 
     /**


### PR DESCRIPTION
Extending GormEntity causes some weird compile issues in certain cases and really isn't needed.

Also, using the plugin, keeping isAuditable seems more natural.