### PR TITLE
Fixed checking of the pull request in the travis-build.sh

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -14,7 +14,7 @@ if [[ $EXIT_STATUS -ne 0 ]]; then
     exit $EXIT_STATUS
 fi
 
-if [ "${TRAVIS_PULL_REQUEST}" == 'true' ]; then
+if [ "${TRAVIS_PULL_REQUEST}" != 'false' ]; then
   echo "*** Stopping further execution, as this is a PR."
   exit $EXIT_STATUS
 fi


### PR DESCRIPTION
I checked that the PR builds fail and found out that the pull request check does not work.

https://docs.travis-ci.com/user/environment-variables/

"TRAVIS_PULL_REQUEST is set to the pull request number if the current job is a pull request build, or false if it’s not."