### PR TITLE
Refactor listener to queue changes and commit as part of transaction synchronization

### DIFF
--- a/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogListener.groovy
+++ b/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogListener.groovy
@@ -120,6 +120,16 @@ class AuditLogListener extends AbstractPersistenceEventListener {
 
         if (map || !verbose) {
             if (auditEventType == AuditEventType.DELETE) {
+                map = map.collectEntries { String property, Object value ->
+                    // Accessing a hibernate PersistentCollection of a deleted entity yields a NPE in Grails 3.3.x.
+                    // We can't filter hibernate classes because this plugin is ORM-agnostic and has no dependency to any ORM implementation.
+                    // This is a workaround. We might not log some other ORM collection implementation even if it would be possible to log them.
+                    // (see #153)
+                    if (value instanceof Collection) {
+                        return [:]
+                    }
+                    return [(property):value]
+                } as Map<String, Object>
                 logChanges(domain, [:], map, auditEventType)
             }
             else {

--- a/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogQueueManager.groovy
+++ b/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogQueueManager.groovy
@@ -1,0 +1,37 @@
+package grails.plugins.orm.auditable
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.grails.datastore.gorm.GormEntity
+import org.springframework.core.NamedThreadLocal
+import org.springframework.transaction.support.TransactionSynchronizationManager
+
+/**
+ * Queue audit logging changes for flushing on transaction commit to ensure proper transactional semantics
+ *
+ * @author Aaron Long
+ */
+@Slf4j
+@CompileStatic
+class AuditLogQueueManager {
+    private static final ThreadLocal<AuditLogTransactionSynchronization> threadLocal = new NamedThreadLocal<AuditLogTransactionSynchronization>("auditLog.synch")
+
+    static void addToQueue(GormEntity auditInstance) {
+        AuditLogTransactionSynchronization auditLogSync = threadLocal.get()
+        if (!auditLogSync) {
+            auditLogSync = registerSynchronization()
+            threadLocal.set(auditLogSync)
+        }
+        auditLogSync.addToQueue(auditInstance)
+    }
+
+    private static AuditLogTransactionSynchronization registerSynchronization() {
+        AuditLogTransactionSynchronization auditLogSync = new AuditLogTransactionSynchronization()
+        TransactionSynchronizationManager.registerSynchronization(auditLogSync)
+        if (log.isDebugEnabled()) {
+            log.debug("Registered new audit log transaction synchronization $auditLogSync")
+        }
+        auditLogSync
+    }
+}
+

--- a/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogTransactionSynchronization.groovy
+++ b/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogTransactionSynchronization.groovy
@@ -1,0 +1,39 @@
+package grails.plugins.orm.auditable
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.grails.datastore.gorm.GormEntity
+import org.springframework.transaction.support.TransactionSynchronizationAdapter
+
+@Slf4j
+@CompileStatic
+class AuditLogTransactionSynchronization extends TransactionSynchronizationAdapter {
+    private List<GormEntity> pendingAuditInstances = []
+
+    void addToQueue(GormEntity auditInstance) {
+        pendingAuditInstances << auditInstance
+        if (log.isTraceEnabled()) {
+            log.trace("Added $auditInstance to synchronization queue")
+        }
+    }
+
+    @Override
+    void afterCommit() {
+        if (!pendingAuditInstances) {
+            return
+        }
+        try {
+            if (log.isDebugEnabled()) {
+                log.debug("Writing ${pendingAuditInstances.size()} pending audit instances in afterCommit()")
+            }
+            AuditLogListenerUtil.getAuditDomainClass().invokeMethod("withNewTransaction") {
+                for (GormEntity entity in pendingAuditInstances) {
+                    entity.save(failOnError: true)
+                }
+            }
+        }
+        finally {
+            pendingAuditInstances.clear()
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 rootProject.name = 'grails-audit-logging'
 
 include 'plugin'
-include 'examples/audit-test'
+include 'examples:audit-test'
 
 findProject(":plugin").name = "audit-logging"


### PR DESCRIPTION
This change is modeled after the hibernate-envers library, which does essentially the same thing in a native hibernate application. 

Starting with Hibernate 5.2+, a transaction is required for all persistence operations. However, the hibernate listeners can't easily participate in the transaction that is causing the audit events. This poses a problem for ensuring that audit events are only written in the case that a transaction is actually committed.

This change queues the audit events for the entire transaction and essentially flushes them after the transaction has successfully committed. This allows the listener to use its own session and transaction as required by hibernate.

Still need to fix the tests and do some failure/negative testing to see what happens if the audit log commit fails. This change guarantees that no audit log entries will ever be written for a transaction that didn't commit, but it might still be possible to NOT write audit log entries for a transaction that does commit. Might be able to switch to `beforeCommit()` to allow a failure to rollback the outer transaction although that might expose the opposite problem.