### PR TITLE
Fix to have plugin create an AuditListener instance for each DataSource being managed within an application

### DIFF
--- a/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLoggingGrailsPlugin.groovy
+++ b/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLoggingGrailsPlugin.groovy
@@ -71,22 +71,33 @@ class AuditLoggingGrailsPlugin extends Plugin {
         Set<String> excludedDataStores = (config.getProperty("excludedDataSources") ?: []) as Set<String>
 
         applicationContext.getBeansOfType(Datastore).each { String key, Datastore datastore ->
-            // mongo datastores don't have a dataSourceName property
-            if (datastore.getProperties().containsKey("dataSourceName")) {
-                String dataSourceName = datastore.metaClass.getProperty(datastore, 'dataSourceName')
 
-                if (!config.disabled && !excludedDataStores.contains(dataSourceName)) {
-                    applicationContext.addApplicationListener(new AuditLogListener(datastore, grailsApplication))
-                }
-                if (config.stampEnabled && !excludedDataStores.contains(dataSourceName)) {
-                    applicationContext.addApplicationListener(new StampListener(datastore, grailsApplication))
-                }
-            } else {
-                if (!config.disabled) {
-                    applicationContext.addApplicationListener(new AuditLogListener(datastore, grailsApplication))
-                }
-                if (config.stampEnabled) {
-                    applicationContext.addApplicationListener(new StampListener(datastore, grailsApplication))
+            //Retrieve all dataSources being managed by the DataStore within the application (i.e. child DataStores)
+            Map<String, String>  dataSources = datastore.metaClass.getProperty(datastore, 'datastoresByConnectionSource')
+
+            //Iterate through each DataSource to determine if they should have an AuditLogListener or StampListener instantiated for them
+            dataSources.each {
+                //Retrieve the specific childDataStore for a DataSource
+                Datastore childDataStore = datastore.getDatastoreForConnection(it.getKey().toString())
+
+                // mongo datastores don't have a dataSourceName property
+                if (childDataStore.getProperties().containsKey("dataSourceName")) {
+
+                    String dataSourceName = childDataStore.metaClass.getProperty(datastore, 'dataSourceName')
+
+                    if (!config.disabled && !excludedDataStores.contains(dataSourceName)) {
+                        applicationContext.addApplicationListener(new AuditLogListener(childDataStore, grailsApplication))
+                    }
+                    if (config.stampEnabled && !excludedDataStores.contains(dataSourceName)) {
+                        applicationContext.addApplicationListener(new StampListener(childDataStore, grailsApplication))
+                    }
+                } else {
+                    if (!config.disabled) {
+                        applicationContext.addApplicationListener(new AuditLogListener(childDataStore, grailsApplication))
+                    }
+                    if (config.stampEnabled) {
+                        applicationContext.addApplicationListener(new StampListener(childDataStore, grailsApplication))
+                    }
                 }
             }
         }


### PR DESCRIPTION
At the current moment, it appears that the audit-logging plugin actually only processes each DataStore, within the doWithApplicationContext() method in AuditLoggingGrailsPlugin.groovy. While this DataStore does contain child DataStores, for instances where an application might have multiple DataSources defined (see example below), I found that an AuditLogListener is only actually instantiated for the DEFAULT DataSource. 

In order to get around this issue, for instances where the DEFAULT DataSource is not the only one that someone would want audit logging being done on, I have gone ahead and made a modification where the names of the various DataSources being included in the DataStore are extracted and then used to pull the associated child DataStore. This way a AuditLogListener is being instantiated for each DataSource within a single DataStore.

**Sample DataSource structure in Grails 3 and above:**
```environments {
   development {
      dataSource {
         pooled = true
         driverClassName = "net.sourceforge.jtds.jdbc.Driver"
         url = "jdbc:jtds:sqlserver://ld-sql.ldprod.local:1433;DatabaseName=services"
         dbCreate = "validate" 
         logSql = false
         properties = sharedProperties
         dialect = "org.hibernate.dialect.SQLServer2012Dialect"
      }
      dataSources {
         ops {
            pooled = true
            driverClassName = "net.sourceforge.jtds.jdbc.Driver"
            url = "jdbc:jtds:sqlserver://ld-sql.ldprod.local:1433;DatabaseName=ops"
            dbCreate = "validate" 
            logSql = false
            properties = sharedProperties
            dialect = "org.hibernate.dialect.SQLServer2012Dialect"
         }
         cases {
            pooled = true
            driverClassName = "net.sourceforge.jtds.jdbc.Driver"
            url = "jdbc:jtds:sqlserver://ld-sql:1433;DatabaseName=cases"
            dbCreate = "validate" 
            logSql = false
            properties = sharedProperties
            dialect = "org.hibernate.dialect.SQLServer2012Dialect"
         }
      }
   }
}