### PR TITLE
add option to use getOriginalValue() for dirty properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ audit-logging/classes
 classes
 /.asscache
 /audit-test/.asscache
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 ## Fork Notes
 
-Forked original project to deal with getPersistentValue() for domain objects' dirty properties always being null. This may
+Forked original project to deal with ``getPersistentValue()`` for domain objects' dirty properties always being null. This may
 be related to using multiple datasources, but I'm not sure.
 
-The workaround is to use getOriginalValue() instead. This is configurable using `auditLog.usePersistentDirtyPropertyValues`,
-which defaults to `true`, so the original behavior of the project is unchanged. All tests pass regardless of the value.
+The workaround is to use ``getOriginalValue()`` instead. This is configurable using `grails.plugin.auditLog.usePersistentDirtyPropertyValues`,
+which defaults to `true`, so the original behavior of the project is unchanged. A value of `false` will cause ``getOriginalValue()`` to be
+called instead of ``getPersistentValue()`` in `AuditLogListenerUtil.groovy`. All tests pass regardless of the value.
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,5 @@
 # Grails Audit Logging Plugin
 
-## Fork Notes
-
-Forked original project to deal with ``getPersistentValue()`` for domain objects' dirty properties always being null. This may
-be related to using multiple datasources, but I'm not sure.
-
-The workaround is to use ``getOriginalValue()`` instead. This is configurable using `grails.plugin.auditLog.usePersistentDirtyPropertyValues`,
-which defaults to `true`, so the original behavior of the project is unchanged. A value of `false` will cause ``getOriginalValue()`` to be
-called instead of ``getPersistentValue()`` in `AuditLogListenerUtil.groovy`. All tests pass regardless of the value.
-
 ## Description
 
 The Audit Logging plugin for Grails adds generic event based Audit Logging to a Grails project.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # Grails Audit Logging Plugin
 
+## Fork Notes
+
+Forked original project to deal with getPersistentValue() for domain objects' dirty properties always being null. This may
+be related to using multiple datasources, but I'm not sure.
+
+The workaround is to use getOriginalValue() instead. This is configurable using `auditLog.usePersistentDirtyPropertyValues`,
+which defaults to `true`, so the original behavior of the project is unchanged. All tests pass regardless of the value.
+
+## Description
+
 The Audit Logging plugin for Grails adds generic event based Audit Logging to a Grails project.
 
-The master branch holds the codebase for plugin version 3.0.x (Grails 3.3.x). 
+The master branch holds the codebase for plugin version 3.0.x (Grails 3.3.x).
 
 For older Grails versions, see "Supported Grails Versions" below.
 
@@ -13,22 +23,22 @@ For older Grails versions, see "Supported Grails Versions" below.
  * For 1.x documentation, see [1.x Grails Plugin Page](http://grails.org/plugin/audit-logging "Grails Plugin Page")
 
 ## Supported Grails versions
- * Grails   3.3.x: [master branch](https://github.com/robertoschwald/grails-audit-logging-plugin/tree/master) 
+ * Grails   3.3.x: [master branch](https://github.com/robertoschwald/grails-audit-logging-plugin/tree/master)
  * Grails   3.0.x-3.2.x: [2.x_maintenance branch](https://github.com/robertoschwald/grails-audit-logging-plugin/tree/2.x_maintenance)
  * Grails   2.x: [1.x_maintenance branch](https://github.com/robertoschwald/grails-audit-logging-plugin/tree/1.x_maintenance)
 
 ## audit-quickstart
-You need to perform "grails audit-quickstart \<package\> \<DomainClass\>" after installing this plugin's 2.0.x version or later. 
+You need to perform "grails audit-quickstart \<package\> \<DomainClass\>" after installing this plugin's 2.0.x version or later.
 See issue [#13](https://github.com/robertoschwald/grails-audit-logging-plugin/issues/13)
-  
-With this, you get an auditlog domain class in your project which is fully under your control. 
+
+With this, you get an auditlog domain class in your project which is fully under your control.
 The domain name is registered in your application.groovy with key "grails.plugins.auditLog.auditDomainClassName".
-  
+
 Example:
-  
+
 ```
 grails audit-quickstart org.example.myproject MyAuditLogEvent
-  
+
 ```
 
 ## Issue Management
@@ -67,7 +77,7 @@ Special thanks to all the contributors (in alphabetical order):
 	Semyon Atamas
 	Shawn Hartsock
 	Tom Crossland
-	
+
 	Project lead: Robert Oschwald
 
 

--- a/plugin/grails-app/conf/DefaultAuditLogConfig.groovy
+++ b/plugin/grails-app/conf/DefaultAuditLogConfig.groovy
@@ -27,6 +27,7 @@ defaultAuditLog {
     mask = ['password']
     propertyMask = "**********"
     defaultActor = 'SYS'
+    usePersistentDirtyPropertyValues = true
 
     // Enable support for Stampable
     stampEnabled = true

--- a/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogListener.groovy
+++ b/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogListener.groovy
@@ -160,7 +160,7 @@ class AuditLogListener extends AbstractPersistenceEventListener {
             if (dirtyProperties) {
 
                 // Get the prior values for everything that is dirty
-                oldMap = dirtyProperties.collectEntries { String property -> [property, getPersistentValue(domain, property)] }
+                oldMap = dirtyProperties.collectEntries { String property -> [property, getOriginalValue(domain, property)] }
 
                 // Get the current values for everything that is dirty
                 newMap = makeMap(dirtyProperties, domain)

--- a/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogListenerUtil.groovy
+++ b/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogListenerUtil.groovy
@@ -43,6 +43,8 @@ class AuditLogListenerUtil {
      */
     static GormEntity createAuditLogDomainInstance(Map params) {
         Class<GormEntity> clazz = getAuditDomainClass()
+        log.debug 'clazz: {}', clazz
+        log.debug 'params: {}', params
         clazz.newInstance(params)
     }
 

--- a/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogListenerUtil.groovy
+++ b/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogListenerUtil.groovy
@@ -66,13 +66,26 @@ class AuditLogListenerUtil {
     }
 
     /**
-     * Get the persistent value for the given domain.property. This method includes
+     * Get the original or persistent value for the given domain.property. This method includes
      * some special case handling for hasMany properties, which don't follow normal rules.
+     *
+     * Default value of AuditLogConfig.usePersistentDirtyPropertyValue is 'true'. If that does not
+     * work (i.e., original value is always null), then use 'false' instead.
+     *
+     * @see http://gorm.grails.org/6.1.x/api/org/grails/datastore/gorm/GormEntity.html#getPersistentValue(java.lang.String)
+     * @see http://gorm.grails.org/6.1.x/api/org/grails/datastore/mapping/dirty/checking/DirtyCheckable.html#getOriginalValue(java.lang.String)
      */
-    static Object getPersistentValue(Auditable domain, String propertyName) {
+    static Object getOriginalValue(Auditable domain, String propertyName) {
         PersistentEntity entity = getPersistentEntity(domain)
         PersistentProperty property = entity.getPropertyByName(propertyName)
-        property instanceof ToMany ? "N/A" : ((GormEntity)domain).getPersistentValue(propertyName)
+        ConfigObject config = AuditLoggingConfigUtils.getAuditConfig()
+        boolean usePersistentDirtyPropertyValues = config.getProperty("usePersistentDirtyPropertyValues")
+        if (usePersistentDirtyPropertyValues) {
+            property instanceof ToMany ? "N/A" : ((GormEntity)domain).getPersistentValue(propertyName)
+        }
+        else {
+            property instanceof ToMany ? "N/A" : ((GormEntity)domain).getOriginalValue(propertyName)
+        }
     }
 
     /**

--- a/plugin/src/main/groovy/grails/plugins/orm/auditable/Auditable.groovy
+++ b/plugin/src/main/groovy/grails/plugins/orm/auditable/Auditable.groovy
@@ -4,6 +4,9 @@ import grails.plugins.orm.auditable.resolvers.AuditRequestResolver
 import grails.util.GrailsNameUtils
 import grails.util.Holders
 import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.grails.datastore.gorm.GormEntity
 import org.grails.datastore.mapping.dirty.checking.DirtyCheckable
 import org.grails.datastore.mapping.model.PersistentEntity
@@ -15,6 +18,8 @@ import javax.persistence.Transient
  */
 @CompileStatic
 trait Auditable {
+    final static Logger log = LoggerFactory.getLogger(Auditable.class)
+
     /**
      * If false, this entity will not be logged
      */
@@ -145,10 +150,13 @@ trait Auditable {
      */
     @Transient
     String getLogEntityId() {
+        log.debug("getLogEntityId()")
         if (this instanceof GormEntity) {
+            log.debug("    this instanceof GormEntity")
             return convertLoggedPropertyToString("id", ((GormEntity)this).ident())
         }
         if (this.respondsTo("getId")) {
+            log.debug("    this respondsTo getId")
             return convertLoggedPropertyToString("id", this.invokeMethod("getId", null))
         }
 
@@ -163,16 +171,21 @@ trait Auditable {
      * @return
      */
     String convertLoggedPropertyToString(String propertyName, Object value) {
+        log.debug("convertLoggedPropertyToString(propertyName: ${propertyName}, value: ${value})")
         if (value instanceof Enum) {
+            log.debug("    value instanceof Enum")
             return ((Enum)value).name()
         }
         if (value instanceof Auditable) {
+            log.debug("    value instanceof Auditable")
             return "[id:${((Auditable)value).logEntityId}]$value"
         }
         if (value instanceof GormEntity) {
+            log.debug("    value instanceof GormEntity")
             return "[id:${((GormEntity)value).ident()}]$value"
         }
         if (value instanceof Collection) {
+            log.debug("    value instanceof Collection")
             if (logAssociatedIds) {
                 return ((Collection)value).collect {
                     convertLoggedPropertyToString(propertyName, it)
@@ -183,6 +196,7 @@ trait Auditable {
             }
         }
 
+        log.debug("    value.toString(): ${value?.toString()}")
         value?.toString()
     }
 


### PR DESCRIPTION
Add configurable option to use getOriginalValue() instead of getPersistentValue() for domain objects' dirty properties. These changes address Issue #190 while leaving the original behavior unchanged.