### PR TITLE
Use withTransaction instead of withNewTransaction, support inlining plugin

### DIFF
--- a/gradle/grailsPublish.gradle
+++ b/gradle/grailsPublish.gradle
@@ -3,8 +3,11 @@ def setIfNotSet = { String name, value ->
     project.ext[name] = value
   }
 }
-setIfNotSet 'issueTrackerUrl', project.vcsUrl + '/issues'
-setIfNotSet 'websiteUrl', project.vcsUrl
+
+if (project.hasProperty("vcsUrl")) {
+  setIfNotSet 'issueTrackerUrl', project.vcsUrl + '/issues'
+  setIfNotSet 'websiteUrl', project.vcsUrl
+}
 
 grailsPublish {
   user = System.getenv("BINTRAY_USER") ?: project.hasProperty("bintrayUser") ? project.bintrayUser : ''

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     provided "org.grails:grails-plugin-services"
     provided "org.grails:grails-plugin-domain-class"
 
-    testCompile "org.grails:grails-plugin-testing"
+    testCompile "org.grails:grails-gorm-testing-support"
     testCompile "org.grails:grails-web-testing-support"
 }
 

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -77,9 +77,9 @@ task wrapper(type: Wrapper) {
     gradleVersion = gradleWrapperVersion
 }
 
-apply from: "${rootProject.projectDir}/gradle/grailsPublish.gradle"
-apply from: "${rootProject.projectDir}/gradle/artifactoryPublish.gradle"
-apply from: "${rootProject.projectDir}/gradle/docs.gradle"
+apply from: "../gradle/grailsPublish.gradle"
+apply from: "../gradle/artifactoryPublish.gradle"
+apply from: "../gradle/docs.gradle"
 
 
 

--- a/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogListener.groovy
+++ b/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogListener.groovy
@@ -184,10 +184,7 @@ class AuditLogListener extends AbstractPersistenceEventListener {
         log.debug("Audit logging event {} and domain {}", eventType, domain.getClass().name)
 
         // Wrap all of the logging in a single session to prevent flushing for each insert
-        // FIXME - Temporary workaround for Grails 4.
-        //         This is not correct sematically as we really need to be part of the transaction or at least ensure
-        //         that audit logging is only committed when the transaction is committed.
-        getAuditDomainClass().invokeMethod("withNewTransaction") {
+        getAuditDomainClass().invokeMethod("withTransaction") {
             Long persistedObjectVersion = getPersistedObjectVersion(domain, newMap, oldMap)
 
             // Use a single date for all audit_log entries in this transaction


### PR DESCRIPTION
Use `withTransaction` instead of `withNewTransaction` to reuse an existing transaction.

I think this makes more sense as in most cases we already should have an existing transaction and in this way we only store audit log events in case the outer transaction commits.

@longwa I understand that the `withNewTransaction` was only a workaround for Grails 4 but isn't `withTransaction` a better workaround? 