### PR TITLE
Fix nested withoutAuditLog calls

### DIFF
--- a/examples/audit-test/src/integration-test/groovy/test/AuditableSpec.groovy
+++ b/examples/audit-test/src/integration-test/groovy/test/AuditableSpec.groovy
@@ -201,6 +201,20 @@ class AuditableSpec extends Specification {
         then:
         compositeId.logEntityId == "[author:$author.id, string:string, nonAuditableCompositeId:toString_for_non_auditable_foo_bar]"
     }
+
+    void "test nested withConfig"() {
+        when:
+        Boolean isDisabled = null
+        AuditLogContext.withoutAuditLog {
+            AuditLogContext.withoutAuditLog {
+                // no-op
+            }
+            isDisabled = AuditLogContext.context.disabled
+        }
+
+        then:
+        isDisabled
+    }
 }
 
 

--- a/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogContext.groovy
+++ b/plugin/src/main/groovy/grails/plugins/orm/auditable/AuditLogContext.groovy
@@ -37,12 +37,15 @@ class AuditLogContext {
      *
      */
     static withConfig(Map config, Closure block) {
+        def previousValue = null
         try {
+            // First getting and then setting should be okay as we use a ThreadLocal so no race conditions should be possible
+            previousValue = auditLogConfig.get()
             auditLogConfig.set(mergeConfig(config))
             block.call()
         }
         finally {
-            auditLogConfig.remove()
+            auditLogConfig.set(previousValue)
         }
     }
 


### PR DESCRIPTION
Previously the test failed because when the inner call returned it cleared the value and didn’t set it to previous value